### PR TITLE
add button type to show password button

### DIFF
--- a/web/src/components/ShowHidePassword/ShowHidePassword.tsx
+++ b/web/src/components/ShowHidePassword/ShowHidePassword.tsx
@@ -19,7 +19,7 @@ const ShowHidePassword = ({ label, name, ...rest }) => {
       ) : (
         <PasswordField name={name} placeholder=" " {...rest} />
       )}
-      <button className="absolute right-6 top-8" onClick={toggleShowPassword}>
+      <button className="absolute right-6 top-8" onClick={toggleShowPassword} type="button">
         {isPasswordShowing ? (
           <Icon id="eyeOpened" size={32} />
         ) : (


### PR DESCRIPTION
Prevents the button click to be triggered during the implicit submission. Without that when the form gets submitted via pressing enter with an input in focus the button gets clicked  and password is shown for a moment before the dashboard loads.

![Peek 2023-12-08 12-20](https://github.com/AdventOfJavaScript/2023-12-03__login-pages/assets/3692560/f7601bd4-585b-4025-be13-26e17de51549)

I am creating this because this detail of how a html form works was unknown to me and I actually learned something new when researching this behaviour.

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission
https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type